### PR TITLE
Add csslint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Theme Check plugin using sniffs. `WordPress-Theme` standard is used from [WPTRT/
 
 * Clone this repo under `wp-content/plugins/`
 * Run `composer install`
+* Run `npm install`
 * Activate plugin
 
 ## Using

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -7,6 +7,8 @@
 		<exclude name="PHPCompatibility.PHP.DefaultTimezoneRequired.Missing"/>
 	</rule>
 
-	<rule ref="Generic.Debug.CSSLint"/>
+	<rule ref="Generic.Debug.CSSLint.ExternalTool">
+		<type>error</type>
+	</rule>
 
 </ruleset>

--- a/bin/phpcs.xml
+++ b/bin/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Check">
+
+	<description>WordPress Theme Check standards.</description>
+
+	<rule ref="PHPCompatibility">
+		<exclude name="PHPCompatibility.PHP.DefaultTimezoneRequired.Missing"/>
+	</rule>
+
+	<rule ref="Generic.Debug.CSSLint"/>
+
+</ruleset>

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -168,6 +168,7 @@ function ns_theme_check_do_sniff( $theme_slug, $args = array() ) {
 
 	// Path to WordPress Theme coding standard.
 	PHP_CodeSniffer::setConfigData( 'installed_paths', NS_THEME_CHECK_DIR . '/vendor/wp-coding-standards/wpcs/', true );
+	PHP_CodeSniffer::setConfigData( 'csslint_path', NS_THEME_CHECK_DIR . '/node_modules/csslint/dist/cli.js --errors=errors', true );
 
 	// Set default standard.
 	PHP_CodeSniffer::setConfigData( 'default_standard', 'WordPress-Theme', true );
@@ -209,7 +210,7 @@ function ns_theme_check_do_sniff( $theme_slug, $args = array() ) {
 		$values['standard'] = $args['standard'];
 	}
 
-	$args['standard'][] = 'PHPCompatibility';
+	$values['standard'][] = NS_THEME_CHECK_DIR . '/bin/phpcs.xml';
 
 	// Sniff theme files.
 	if ( isset( $args['raw_output'] ) && 1 === absint( $args['raw_output'] ) ) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ns-theme-check",
+  "version": "1.0.0",
+  "description": "Theme Check plugin using sniffs. `WordPress-Theme` standard is used from WPTRT/WordPress-Coding-Standards.",
+  "main": "index.js",
+  "dependencies": {
+    "csslint": "^1.0.5"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ernilambar/ns-theme-check.git"
+  },
+  "author": "Nilambar Sharma <nilambar@outlook.com>",
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/ernilambar/ns-theme-check/issues"
+  },
+  "homepage": "https://github.com/ernilambar/ns-theme-check#readme"
+}


### PR DESCRIPTION
To test you need to run `npm install` in the plugin directory and requires node to be installed on the server.

I have not yet tested the plugin on a server where node is not installed.