### PR TITLE
Ignore node_modules

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -217,6 +217,11 @@ function ns_theme_check_do_sniff( $theme_slug, $args = array() ) {
 
 	$values['standard'][] = NS_THEME_CHECK_DIR . '/bin/phpcs.xml';
 
+	// Ignore unrelated files from the check.
+	$values['ignored'] = array(
+		'.*/node_modules/.*',
+	);
+
 	// Sniff theme files.
 	if ( isset( $args['raw_output'] ) && 1 === absint( $args['raw_output'] ) ) {
 		echo '<div class="theme-check-report theme-check-report-raw">';


### PR DESCRIPTION
When running the check on a theme that was in development I was running out of memory. By excluding the the node_modules folder it worked again. This is useful when developing a theme.

We can restrict the use of `node_modules` in another check. 