### PR TITLE
Fix sprintf placeholder.

### DIFF
--- a/src/helpers/readme-helpers-trait.php
+++ b/src/helpers/readme-helpers-trait.php
@@ -136,7 +136,7 @@ trait Readme_Helpers {
 		} elseif ( ! empty( $response->deprecated ) ) { // Deprecated match found.
 			$response->status = 'warning';
 			/* translators: %s: User provided license identifier. */
-			$response->message = sprintf( esc_html__( 'The license identification provided, $s, indicates a deprecated license!  Please use a valid SPDX Identifier!', 'theme-sniffer' ), $response->provided );
+			$response->message = sprintf( esc_html__( 'The license identification provided, %s, indicates a deprecated license!  Please use a valid SPDX Identifier!', 'theme-sniffer' ), $response->provided );
 		} else { // No matches found.
 			$response->status = 'warning';
 			/* translators: %s: unrecognized user provided license identifier */


### PR DESCRIPTION
I just found this small issue with the sprintf placeholder while testing a theme with  theme-sniffer, which blocking the actual warning message from being print on the screen.
This also mentioned in this comment https://github.com/WPTT/theme-sniffer/issues/178#issuecomment-519087046