### PR TITLE
Allow line breaks between headers in readme.txt

### DIFF
--- a/src/sniffs/readme/class-parser.php
+++ b/src/sniffs/readme/class-parser.php
@@ -230,11 +230,11 @@ class Parser {
 			$value = null;
 			if ( false === strpos( $line, ':' ) ) {
 
-				// Some plugins have line-breaks within the headers.
+				// Some themes have line-breaks within the headers.
 				if ( empty( $line ) ) {
-					break;
-				} else {
 					continue;
+				} else {
+					break;
 				}
 			}
 


### PR DESCRIPTION
Line breaks between headers are not forbidden, but the readme.txt parser failed if there was an empty line between them.

The parser code is intended to allow line breaks between headers, but a small bug prevented this.

Resolves: #226